### PR TITLE
ci: auto-merge minor Dependabot bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,9 +11,10 @@ jobs:
       - name: Fetch Dependabot metadata
         id: meta
         uses: dependabot/fetch-metadata@v2
-      - name: Auto-merge patch + security updates
+      - name: Auto-merge patch + minor + security updates
         if: |
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
           contains(github.event.pull_request.labels.*.name, 'security')
         run: gh pr merge --auto --squash "$PR_URL"
         env:


### PR DESCRIPTION
Widens policy from 'patch + security' to 'patch + minor + security'.
Major bumps still require manual review.
